### PR TITLE
Fix coveralls badge

### DIFF
--- a/.github/workflows/buildImage.yml
+++ b/.github/workflows/buildImage.yml
@@ -45,3 +45,4 @@ jobs:
           server-stage: stage3
           build-args: |
             PY_VERSION=${{ matrix.python-version }}
+# comment to make buildImage run

--- a/.github/workflows/buildImage.yml
+++ b/.github/workflows/buildImage.yml
@@ -1,6 +1,7 @@
 name: build-docker-image
 
 on: 
+  workflow_dispatch:
   push:
     paths:
       - 'Dockerfile'
@@ -22,11 +23,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: Log in to the Container Registry
         uses: docker/login-action@v2
         with:
@@ -45,4 +41,3 @@ jobs:
           server-stage: stage3
           build-args: |
             PY_VERSION=${{ matrix.python-version }}
-# comment to make buildImage run

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,4 @@ RUN echo stage2
 FROM stage2 AS stage3
 RUN pip install -U pytest coverage
 COPY . .
+RUN echo stage3

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,3 @@ RUN echo stage2
 FROM stage2 AS stage3
 RUN pip install -U pytest coverage
 COPY . .
-RUN echo stage3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # learn-maintenance
 
 ### Project Status
-[![Coverage Status](https://coveralls.io/repos/github/bquan0/learn-maintenance/badge.svg?branch=badges)](https://coveralls.io/github/bquan0/learn-maintenance?branch=badges)
+[![Coverage Status](https://coveralls.io/repos/github/CNERG/learn-maintenance/badge.svg?branch=main)](https://coveralls.io/github/CNERG/learn-maintenance?branch=main)
 ![GitHub issues](https://img.shields.io/github/issues/cnerg/learn-maintenance)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/cnerg/learn-maintenance)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # learn-maintenance
 
 ### Project Status
-[![Coverage Status](https://coveralls.io/repos/github/CNERG/learn-maintenance/badge.svg?branch=main)](https://coveralls.io/github/CNERG/learn-maintenance?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/cnerg/learn-maintenance/badge.svg?branch=main)](https://coveralls.io/github/cnerg/learn-maintenance?branch=main)
 ![GitHub issues](https://img.shields.io/github/issues/cnerg/learn-maintenance)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/cnerg/learn-maintenance)
 


### PR DESCRIPTION
Updated the coveralls badge to refer to the CNERG fork of the learn-maintenance repository as requested by issue #10 