### PR TITLE
fix buildImage.yml

### DIFF
--- a/.github/workflows/buildImage.yml
+++ b/.github/workflows/buildImage.yml
@@ -8,7 +8,6 @@ on:
 
 env: 
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-image:
@@ -35,17 +34,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v1
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.actor }}/learn-maintenance-image:latest${{ matrix.python-version }}
-          labels: ${{ steps.meta.outputs.labels }} 
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
     


### PR DESCRIPTION
This pull request adds the changes to `buildImage.yml` from #13. This is to split #13 into two pull requests: one to fix `buildImage.yml` and one to fix `testing.yml`. This is necessary because `buildImage.yml` needs to be fixed in the CNERG repository to provide the necessary docker images for `testing.yml` to properly run. 

The changes to `buildImage.yml` include:
- using `env.REGISTRY` to replace `ghcr.io`
- replacing `github.actor` with `github.repository` in the tag for the docker images
- removing the `Extract metadata` step (because it doesn't seem to affect the building of the images)
- removing `env.IMAGE_NAME` because it was only referenced once. 