### PR TITLE
build images with different python versions

### DIFF
--- a/.github/workflows/buildImage.yml
+++ b/.github/workflows/buildImage.yml
@@ -34,10 +34,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
+      - run: docker build -t learn-maintenance-image:latest${{ matrix.python-version }} --build-arg PY_VERSION=${{ matrix.python-version }}
+      - run: docker push ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
+
+      # - name: Build and push Docker image
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     context: .
+      #     push: true
+      #     tags: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
     

--- a/.github/workflows/buildImage.yml
+++ b/.github/workflows/buildImage.yml
@@ -46,6 +46,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.actor }}/learn-maintenance-image:latest${{ matrix.python-version }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
           labels: ${{ steps.meta.outputs.labels }} 
     

--- a/.github/workflows/buildImage.yml
+++ b/.github/workflows/buildImage.yml
@@ -41,5 +41,5 @@ jobs:
           build-args: |
             PY_VERSION=${{ matrix.python-version }}
           push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image-${{ matrix.python-version }}:latest
     

--- a/.github/workflows/buildImage.yml
+++ b/.github/workflows/buildImage.yml
@@ -8,7 +8,6 @@ on:
 
 env: 
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-image:

--- a/.github/workflows/buildImage.yml
+++ b/.github/workflows/buildImage.yml
@@ -34,13 +34,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: docker build \-t learn-maintenance-image:latest${{ matrix.python-version }} \--build-arg PY_VERSION=${{ matrix.python-version }}
-      - run: docker push ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
-
-      # - name: Build and push Docker image
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     context: .
-      #     push: true
-      #     tags: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            PY_VERSION=${{ matrix.python-version }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
     

--- a/.github/workflows/buildImage.yml
+++ b/.github/workflows/buildImage.yml
@@ -34,7 +34,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: docker build -t learn-maintenance-image:latest${{ matrix.python-version }} --build-arg PY_VERSION=${{ matrix.python-version }}
+      - run: docker build \-t learn-maintenance-image:latest${{ matrix.python-version }} \--build-arg PY_VERSION=${{ matrix.python-version }}
       - run: docker push ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
 
       # - name: Build and push Docker image

--- a/.github/workflows/buildImage.yml
+++ b/.github/workflows/buildImage.yml
@@ -35,17 +35,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v1
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
-          labels: ${{ steps.meta.outputs.labels }} 
     

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,10 +8,10 @@ on:
     branches:
       - main
       
-env: 
+env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  
+
 jobs:
   run-test-code:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
   run-test-code:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
+      image: ${{ REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,14 +1,17 @@
 # automatically runs pytest to test the length conversion program whenever code is pushed to github
 
 name: test-conversion-program
+
 on: 
   push:
   pull_request:
     branches:
       - main
+      
 env: 
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  
 jobs:
   run-test-code:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,11 +6,14 @@ on:
   pull_request:
     branches:
       - main
+env: 
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 jobs:
   run-test-code:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cnerg/learn-maintenance-image:latest${{ matrix.python-version }}
+      image: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,16 +7,12 @@ on:
   pull_request:
     branches:
       - main
-      
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   run-test-code:
     runs-on: ubuntu-latest
     container:
-      image: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
+      image: ghcr.io/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,21 +1,10 @@
 # automatically runs pytest to test the length conversion program whenever code is pushed to github
 
 name: test-conversion-program
-
-on: 
-  push:
-  pull_request:
-    branches:
-      - main
-
+on: push
 jobs:
   run-test-code:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -25,6 +14,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - run: pip install numpy
+      - run: pip install -U pytest coverage
       - run: coverage run -m --source=. pytest
       - run: coverage lcov
       - name: Coveralls GitHub Action

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,10 +1,19 @@
 # automatically runs pytest to test the length conversion program whenever code is pushed to github
 
 name: test-conversion-program
-on: push
+on: 
+  push:
+  pull_request:
+    branches:
+      - main
 jobs:
   run-test-code:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/cnerg/learn-maintenance-image:latest${{ matrix.python-version }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -14,8 +23,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install numpy
-      - run: pip install -U pytest coverage
       - run: coverage run -m --source=. pytest
       - run: coverage lcov
       - name: Coveralls GitHub Action

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
   run-test-code:
     runs-on: ubuntu-latest
     container:
-      image: ${{ REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
+      image: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
   run-test-code:
     runs-on: ubuntu-latest
     container:
-      image: ${{ env.REGISTRY }}/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
+      image: ghcr.io/${{ github.repository }}/learn-maintenance-image:latest${{ matrix.python-version }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.8-slim-buster
+FROM scratch
+ADD ubuntu-focal-oci-amd64-root.tar.gz /
+CMD ["bash"]
 WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 RUN pip install numpy
 RUN pip install -U pytest coverage
 COPY . .
-
-# comment to make build-docker-image workflow run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM scratch
-ADD ubuntu-focal-oci-amd64-root.tar.gz /
-CMD ["bash"]
+FROM ubuntu:18.04
 WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
-
-FROM ubuntu:18.04
+ARG PY_VERSION = 3.8
+FROM python:$PY_VERSION
 WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
+ARG PY_VERSION=3.8
 # syntax=docker/dockerfile:1
-ARG PY_VERSION = 3.8
 FROM python:$PY_VERSION
 WORKDIR /app
 COPY requirements.txt requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 FROM ubuntu:18.04
 WORKDIR /app
 COPY requirements.txt requirements.txt
+RUN apt-get update && apt-get install python-pip
 RUN pip install -r requirements.txt
 RUN pip install numpy
 RUN pip install -U pytest coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,3 @@ RUN pip install -r requirements.txt
 RUN pip install numpy
 RUN pip install -U pytest coverage
 COPY . .
-# comment to make buildImage.yml workflow run

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@
 FROM ubuntu:18.04
 WORKDIR /app
 COPY requirements.txt requirements.txt
-RUN apt-get update && apt-get install python-pip
 RUN pip install -r requirements.txt
 RUN pip install numpy
 RUN pip install -U pytest coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ RUN pip install -r requirements.txt
 RUN pip install numpy
 RUN pip install -U pytest coverage
 COPY . .
+# comment to make buildImage.yml workflow run

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ itsdangerous==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 Werkzeug==1.0.1
-numpy==1.22.0
+numpy==1.21.6
 pytest==7.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ MarkupSafe==1.1.1
 Werkzeug==1.0.1
 numpy==1.23.1
 pytest==7.1.2
+pip==22.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ itsdangerous==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 Werkzeug==1.0.1
-numpy==1.21.6
+numpy
 pytest==7.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ itsdangerous==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 Werkzeug==1.0.1
-numpy==1.23.1
+numpy==1.22.0
 pytest==7.1.2
-pip==22.2.2


### PR DESCRIPTION
This pull request splits #17 into two pull requests: one to fix `buildImage.yml` and one to fix `testing.yml`. This is necessary because `buildImage.yml` needs to be fixed in the CNERG repository to provide the necessary docker images for `testing.yml` to run properly.

Note: all the commits from #17 are included in this PR because I merged the `testing-workflow` branch into the `buildImage-workflow` branch in my repository. 

**Changes:**
`buildImage.yml`
- added a build arg in the `docker/build-push-action` to tell the `Dockerfile` what python version to use when building the image
- moved `latest` to the end of the docker image tag

`Dockerfile`
- changed the base image to be an image of the input python version instead of `python:3.8-slim-buster`
- added a default value for the argument `PY_VERSION` at the top

`requirements.txt`
- removed the specification on which version of `numpy` to use. This way, each docker image will install the latest version of numpy possible for its python version. 