### PR TITLE
fix testing.yml part 2

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,10 +1,21 @@
 # automatically runs pytest to test the length conversion program whenever code is pushed to github
 
 name: test-conversion-program
-on: push
+
+on: 
+  push:
+  pull_request:
+    branches:
+      - main
+
 jobs:
   run-test-code:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}/learn-maintenance-image-${{ matrix.python-version }}:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -14,8 +25,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install numpy
-      - run: pip install -U pytest coverage
       - run: coverage run -m --source=. pytest
       - run: coverage lcov
       - name: Coveralls GitHub Action

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,14 +11,14 @@ on:
 jobs:
   run-test-code:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     container:
       image: ghcr.io/${{ github.repository }}/learn-maintenance-image-${{ matrix.python-version }}:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps: 
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This PR updates `testing.yml` to use the new images generated by `buildImage.yml`
The tests are now running correctly, and the GLIBC_2.29 error for python 3.8 has been fixed. 

Changes to `testing.yml`:
- the workflow now runs when pull requests are merged to main in the `cnerg` repository
- each test uses docker images from GHCR with the respective python version
- removed commands for installing numpy and coverage since those are done in the `dockerfile`.