### PR TITLE
Don't use the setup-python action

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,6 +22,7 @@ jobs:
     steps: 
       - uses: actions/checkout@v3
       
+      - run: python --version
       - run: coverage run -m --source=. pytest
       - run: coverage lcov
       - name: Coveralls GitHub Action

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,10 +21,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps: 
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
+      
       - run: coverage run -m --source=. pytest
       - run: coverage lcov
       - name: Coveralls GitHub Action

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,8 @@
 
 name: test-conversion-program
 
-on: 
+on:
+  workflow_dispatch:
   push:
   pull_request:
     branches:


### PR DESCRIPTION
Each image is built with a specific version of python.  It is redundant - and probably unstable - to call the `setup-python` action over top of this.