### PR TITLE
Run coveralls once

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,21 +27,18 @@ jobs:
       - uses: actions/checkout@v3
       
       - run: python --version
-      - run: echo ${{ matrix.python-version }}
-      - run: echo ${{ env.python-version-for-coveralls }}
-      - run: echo ${{ matrix.python-version }} != ${{ env.python-version-for-coveralls }}
-      - run: echo ${{ matrix.python-version }} == ${{ env.python-version-for-coveralls }}
-      - if: ${{ matrix.python-version }} != ${{ env.python-version-for-coveralls }}
+      - run: echo ${{ matrix.python-version }} = ${{ env.python-version-for-coveralls }} ${{ run-coveralls }}
+      - if: !${{ run-coveralls }}
         run: pytest
-      - if: ${{ matrix.python-version }} == ${{ env.python-version-for-coveralls }}
+      - if: ${{ run-coveralls }}
         run: |
           coverage run -m --source=. pytest
           coverage lcov
-      - if: ${{ matrix.python-version }} == ${{ env.python-version-for-coveralls }}
+      - if: ${{ run-coveralls }}
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: ${{ matrix.python-version }} == ${{ env.python-version-for-coveralls }}
+      - if: ${{ run-coveralls }}
         run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,7 +27,10 @@ jobs:
       - uses: actions/checkout@v3
       
       - run: python --version
-      - run: echo ${{ matrix.python-version }} = "3.7" >> ${{ env.run-coveralls }}
+      - run: |
+          if [[ "${{ matrix.python-version }}" == "3.7" ]]; then
+            echo 'run-coverage=true' >> $GITHUB_ENV
+          fi
       - if: "!${{ env.run-coveralls }}"
         run: pytest
       - if: ${{ env.run-coveralls }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,8 +27,9 @@ jobs:
       - if: ${{ matrix.python-version }} != "3.7"
         run: pytest
       - if: ${{ matrix.python-version }} == "3.7"
-        run: coverage run -m --source=. pytest
-        run: coverage lcov
+        run: |
+          coverage run -m --source=. pytest
+          coverage lcov
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@
 name: test-conversion-program
 
 env: 
-  python-version-for-coveralls: "3.7"
+  python-version-for-coveralls: ${{ "3.7" }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,17 +36,17 @@ jobs:
             echo 'run-coverage=NO' >> $GITHUB_ENV
           fi
       - run: echo ${{ env.run-coverage }}
-      - if: env.run-coveralls == 'NO'
+      - if: matrix.python-version != '3.7'
         run: pytest
-      - if: env.run-coveralls == 'YES'
+      - if: matrix.python-version == '3.7'
         run: |
           coverage run -m --source=. pytest
           coverage lcov
-      - if: env.run-coveralls == 'YES'
+      - if: matrix.python-version == '3.7'
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: env.run-coveralls == 'YES'
+      - if: matrix.python-version == '3.7'
         run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,7 @@ jobs:
       
       - run: python --version
       - run: echo ${{ matrix.python-version }} = "3.7" >> ${{ env.run-coveralls }}
-      - if: !(${{ env.run-coveralls }})
+      - if: "!${{ env.run-coveralls }}"
         run: pytest
       - if: ${{ env.run-coveralls }}
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,7 +38,7 @@ jobs:
       - run: echo ${{ env.run-coverage }}
       - if: '!env.run-coveralls'
         run: pytest
-      - if: env.run-coveralls
+      - if: env.run-coveralls == true
         run: |
           coverage run -m --source=. pytest
           coverage lcov

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   run-pytest-only:
+    name: pytest
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,6 +27,7 @@ jobs:
       - run: pytest
 
   run-coveralls-with-3.7:
+    name: coveralls
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/learn-maintenance-image-3.7:latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,13 +27,14 @@ jobs:
       - uses: actions/checkout@v3
       
       - run: python --version
-      - run: |
-          if [ "${{ matrix.python-version }}" == "3.7" ]; then
+      - shell: bash -l {0}
+        run: |
+          if [[ "${{ matrix.python-version }}" == "3.7" ]]; then
             echo 'run-coverage=true' >> $GITHUB_ENV
           fi
       - if: "!${{ env.run-coveralls }}"
         run: pytest
-      - if: false
+      - if: ${{ env.run-coveralls }}
         run: |
           coverage run -m --source=. pytest
           coverage lcov

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,17 +28,17 @@ jobs:
         run: echo "false"
       - if: true
         run: echo "true"
-      - if: ${{ matrix.python-version }} != "3.7"
+      - if: ${{ matrix.python-version }} != 3.7
         run: pytest
-      - if: ${{ matrix.python-version }} == "3.7"
+      - if: ${{ matrix.python-version }} == 3.7
         run: |
           coverage run -m --source=. pytest
           coverage lcov
-      - if: ${{ matrix.python-version }} == "3.7"
+      - if: ${{ matrix.python-version }} == 3.7
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: ${{ matrix.python-version }} == "3.7"
+      - if: ${{ matrix.python-version }} == 3.7
         run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,12 +27,13 @@ jobs:
       - if: ${{ matrix.python-version }} != "3.7"
         run: pytest
       - if: ${{ matrix.python-version }} == "3.7"
-        run: |
-          coverage run -m --source=. pytest
-          coverage lcov
-        name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@master
-        with:
-          path-to-lcov: ./coverage.lcov
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        run: coverage report
+        steps:
+          - run: |
+              coverage run -m --source=. pytest
+              coverage lcov
+          - name: Coveralls GitHub Action
+            uses: coverallsapp/github-action@master
+            with:
+              path-to-lcov: ./coverage.lcov
+              github-token: ${{ secrets.GITHUB_TOKEN }}
+          - run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,17 +36,17 @@ jobs:
             echo 'run-coverage=false' >> $GITHUB_ENV
           fi
       - run: echo ${{ env.run-coverage }}
-      - if: '!env.run-coveralls'
+      - if: env.run-coveralls == false
         run: pytest
       - if: env.run-coveralls == true
         run: |
           coverage run -m --source=. pytest
           coverage lcov
-      - if: env.run-coveralls
+      - if: env.run-coveralls == true
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: env.run-coveralls
+      - if: env.run-coveralls == true
         run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,12 +28,12 @@ jobs:
       
       - run: python --version
       - run: |
-          if [[ "${{ matrix.python-version }}" == "3.7" ]]; then
+          if [ "${{ matrix.python-version }}" == "3.7" ]; then
             echo 'run-coverage=true' >> $GITHUB_ENV
           fi
       - if: "!${{ env.run-coveralls }}"
         run: pytest
-      - if: ${{ env.run-coveralls }}
+      - if: false
         run: |
           coverage run -m --source=. pytest
           coverage lcov

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
       - run: python --version
       - run: pytest
 
-  run-coveralls-with-3.7:
+  run-coveralls:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/learn-maintenance-image-3.7:latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,17 +36,17 @@ jobs:
             echo 'run-coverage=NO' >> $GITHUB_ENV
           fi
       - run: echo ${{ env.run-coverage }}
-      - if: env.run-coveralls == NO
+      - if: env.run-coveralls == 'NO'
         run: pytest
-      - if: env.run-coveralls == YES
+      - if: env.run-coveralls == 'YES'
         run: |
           coverage run -m --source=. pytest
           coverage lcov
-      - if: env.run-coveralls == YES
+      - if: env.run-coveralls == 'YES'
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: env.run-coveralls == YES
+      - if: env.run-coveralls == 'YES'
         run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,7 @@ jobs:
       
       - run: python --version
       - run: echo ${{ matrix.python-version }} = "3.7" >> ${{ env.run-coveralls }}
-      - if: ! ${{ env.run-coveralls }}
+      - if: !(${{ env.run-coveralls }})
         run: pytest
       - if: ${{ env.run-coveralls }}
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@
 name: test-conversion-program
 
 env: 
-  python-version-for-coveralls: ${{ 3.7 }}
+  run-coveralls: false
 
 on:
   workflow_dispatch:
@@ -27,18 +27,18 @@ jobs:
       - uses: actions/checkout@v3
       
       - run: python --version
-      - run: echo ${{ matrix.python-version }} = ${{ env.python-version-for-coveralls }} >> $run-coveralls 
-      - if: ! ${{ run-coveralls }}
+      - run: echo ${{ matrix.python-version }} = "3.7" >> ${{ env.run-coveralls }}
+      - if: ! ${{ env.run-coveralls }}
         run: pytest
-      - if: ${{ run-coveralls }}
+      - if: ${{ env.run-coveralls }}
         run: |
           coverage run -m --source=. pytest
           coverage lcov
-      - if: ${{ run-coveralls }}
+      - if: ${{ env.run-coveralls }}
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: ${{ run-coveralls }}
+      - if: ${{ env.run-coveralls }}
         run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: actions/checkout@v3
       
       - run: python --version
-      - if: false
-        run: echo "false"
-      - if: true
-        run: echo "true"
+      - run: echo ${{ matrix.python-version }}
+      - run: echo ${{ env.python-version-for-coveralls }}
+      - run: echo ${{ matrix.python-version }} != ${{ env.python-version-for-coveralls }}
+      - run: echo ${{ matrix.python-version }} == ${{ env.python-version-for-coveralls }}
       - if: ${{ matrix.python-version }} != ${{ env.python-version-for-coveralls }}
         run: pytest
       - if: ${{ matrix.python-version }} == ${{ env.python-version-for-coveralls }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,6 +32,7 @@ jobs:
           if [[ "${{ matrix.python-version }}" == "3.7" ]]; then
             echo 'run-coverage=true' >> $GITHUB_ENV
           fi
+      - run: echo ${{ env.run-coverage }}
       - if: "!${{ env.run-coveralls }}"
         run: pytest
       - if: ${{ env.run-coveralls }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@
 name: test-conversion-program
 
 env: 
-  python-version-for-coveralls: ${{ "3.7" }}
+  python-version-for-coveralls: ${{ 3.7 }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,11 +24,14 @@ jobs:
       - uses: actions/checkout@v3
       
       - run: python --version
-      - run: coverage run -m --source=. pytest
-      - run: coverage lcov
-      - name: Coveralls GitHub Action
+      - if: ${{ matrix.python-version }} != "3.7"
+        run: pytest
+      - if: ${{ matrix.python-version }} == "3.7"
+        run: coverage run -m --source=. pytest
+        run: coverage lcov
+        name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: coverage report
+        run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,7 +36,7 @@ jobs:
             echo 'run-coverage=false' >> $GITHUB_ENV
           fi
       - run: echo ${{ env.run-coverage }}
-      - if: !env.run-coveralls
+      - if: '!env.run-coveralls'
         run: pytest
       - if: env.run-coveralls
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   run-pytest-only:
-    name: pytest
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,21 +26,20 @@ jobs:
       - run: pytest
 
   run-coveralls-with-3.7:
-    name: coveralls
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/learn-maintenance-image-3.7:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-     steps: 
-      - uses: actions/checkout@v3   
-      - run: python --version
-      - run: coverage run -m --source=. pytest
-      - run: coverage lcov
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@master
-        with:
-          path-to-lcov: ./coverage.lcov
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: coverage report
+    steps: 
+    - uses: actions/checkout@v3   
+    - run: python --version
+    - run: coverage run -m --source=. pytest
+    - run: coverage lcov
+    - name: Coveralls GitHub Action
+      uses: coverallsapp/github-action@master
+      with:
+        path-to-lcov: ./coverage.lcov
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,13 +27,14 @@ jobs:
       - if: ${{ matrix.python-version }} != "3.7"
         run: pytest
       - if: ${{ matrix.python-version }} == "3.7"
-        steps:
-          - run: |
-              coverage run -m --source=. pytest
-              coverage lcov
-          - name: Coveralls GitHub Action
-            uses: coverallsapp/github-action@master
-            with:
-              path-to-lcov: ./coverage.lcov
-              github-token: ${{ secrets.GITHUB_TOKEN }}
-          - run: coverage report
+        run: |
+          coverage run -m --source=. pytest
+          coverage lcov
+      - if: ${{ matrix.python-version }} == "3.7"
+        name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@master
+        with:
+          path-to-lcov: ./coverage.lcov
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - if: ${{ matrix.python-version }} == "3.7"
+        run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/checkout@v3
       
       - run: python --version
+      - if: false
+        run: echo "false"
+      - if: true
+        run: echo "true"
       - if: ${{ matrix.python-version }} != "3.7"
         run: pytest
       - if: ${{ matrix.python-version }} == "3.7"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,9 +2,6 @@
 
 name: test-conversion-program
 
-env: 
-  run-coveralls: NO
-
 on:
   workflow_dispatch:
   push:
@@ -27,15 +24,6 @@ jobs:
       - uses: actions/checkout@v3
       
       - run: python --version
-      - run: echo ${{ env.run-coverage }}
-      - shell: bash -l {0}
-        run: |
-          if [[ "${{ matrix.python-version }}" == "3.7" ]]; then
-            echo 'run-coverage=YES' >> $GITHUB_ENV
-          else
-            echo 'run-coverage=NO' >> $GITHUB_ENV
-          fi
-      - run: echo ${{ env.run-coverage }}
       - if: matrix.python-version != '3.7'
         run: pytest
       - if: matrix.python-version == '3.7'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - run: python --version
+      - run: echo ${{ env.run-coverage }}
       - shell: bash -l {0}
         run: |
           if [[ "${{ matrix.python-version }}" == "3.7" ]]; then

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - run: python --version
-      - run: echo ${{ matrix.python-version }} = ${{ env.python-version-for-coveralls }} ${{ run-coveralls }}
+      - run: echo ${{ matrix.python-version }} = ${{ env.python-version-for-coveralls }} >> ${{ run-coveralls }}
       - if: ! ${{ run-coveralls }}
         run: pytest
       - if: ${{ run-coveralls }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@
 name: test-conversion-program
 
 env: 
-  run-coveralls: false
+  run-coveralls: NO
 
 on:
   workflow_dispatch:
@@ -31,22 +31,22 @@ jobs:
       - shell: bash -l {0}
         run: |
           if [[ "${{ matrix.python-version }}" == "3.7" ]]; then
-            echo 'run-coverage=true' >> $GITHUB_ENV
+            echo 'run-coverage=YES' >> $GITHUB_ENV
           else
-            echo 'run-coverage=false' >> $GITHUB_ENV
+            echo 'run-coverage=NO' >> $GITHUB_ENV
           fi
       - run: echo ${{ env.run-coverage }}
-      - if: env.run-coveralls == false
+      - if: env.run-coveralls == NO
         run: pytest
-      - if: env.run-coveralls == true
+      - if: env.run-coveralls == YES
         run: |
           coverage run -m --source=. pytest
           coverage lcov
-      - if: env.run-coveralls == true
+      - if: env.run-coveralls == YES
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: env.run-coveralls == true
+      - if: env.run-coveralls == YES
         run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,31 +10,35 @@ on:
       - main
 
 jobs:
-  run-test-code:
+  run-pytest-only:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     container:
       image: ghcr.io/${{ github.repository }}/learn-maintenance-image-${{ matrix.python-version }}:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps: 
-      - uses: actions/checkout@v3
-      
+      - uses: actions/checkout@v3     
       - run: python --version
-      - if: matrix.python-version != '3.7'
-        run: pytest
-      - if: matrix.python-version == '3.7'
-        run: |
-          coverage run -m --source=. pytest
-          coverage lcov
-      - if: matrix.python-version == '3.7'
-        name: Coveralls GitHub Action
+      - run: pytest
+
+  run-coveralls-with-3.7:
+    container:
+      image: ghcr.io/${{ github.repository }}/learn-maintenance-image-3.7:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+     steps: 
+      - uses: actions/checkout@v3   
+      - run: python --version
+      - run: coverage run -m --source=. pytest
+      - run: coverage lcov
+      - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: matrix.python-version == '3.7'
-        run: coverage report
+      - run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,6 +26,7 @@ jobs:
       - run: pytest
 
   run-coveralls-with-3.7:
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/learn-maintenance-image-3.7:latest
       credentials:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,7 @@ jobs:
       
       - run: python --version
       - run: echo ${{ matrix.python-version }} = ${{ env.python-version-for-coveralls }} ${{ run-coveralls }}
-      - if: !${{ run-coveralls }}
+      - if: ! ${{ run-coveralls }}
         run: pytest
       - if: ${{ run-coveralls }}
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,17 +28,17 @@ jobs:
         run: echo "false"
       - if: true
         run: echo "true"
-      - if: ${{ matrix.python-version }} != 3.7
+      - if: ${{ matrix.python-version }} != '3.7'
         run: pytest
-      - if: ${{ matrix.python-version }} == 3.7
+      - if: ${{ matrix.python-version }} == '3.7'
         run: |
           coverage run -m --source=. pytest
           coverage lcov
-      - if: ${{ matrix.python-version }} == 3.7
+      - if: ${{ matrix.python-version }} == '3.7'
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: ${{ matrix.python-version }} == 3.7
+      - if: ${{ matrix.python-version }} == '3.7'
         run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,19 +32,21 @@ jobs:
         run: |
           if [[ "${{ matrix.python-version }}" == "3.7" ]]; then
             echo 'run-coverage=true' >> $GITHUB_ENV
+          else
+            echo 'run-coverage=false' >> $GITHUB_ENV
           fi
       - run: echo ${{ env.run-coverage }}
-      - if: "!${{ env.run-coveralls }}"
+      - if: !env.run-coveralls
         run: pytest
-      - if: ${{ env.run-coveralls }}
+      - if: env.run-coveralls
         run: |
           coverage run -m --source=. pytest
           coverage lcov
-      - if: ${{ env.run-coveralls }}
+      - if: env.run-coveralls
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: ${{ env.run-coveralls }}
+      - if: env.run-coveralls
         run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,6 +2,9 @@
 
 name: test-conversion-program
 
+env: 
+  python-version-for-coveralls: "3.7"
+
 on:
   workflow_dispatch:
   push:
@@ -28,17 +31,17 @@ jobs:
         run: echo "false"
       - if: true
         run: echo "true"
-      - if: ${{ matrix.python-version }} != ${{ "3.7" }}
+      - if: ${{ matrix.python-version }} != ${{ env.python-version-for-coveralls }}
         run: pytest
-      - if: ${{ matrix.python-version }} == ${{ "3.7" }}
+      - if: ${{ matrix.python-version }} == ${{ env.python-version-for-coveralls }}
         run: |
           coverage run -m --source=. pytest
           coverage lcov
-      - if: ${{ matrix.python-version }} == ${{ "3.7" }}
+      - if: ${{ matrix.python-version }} == ${{ env.python-version-for-coveralls }}
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: ${{ matrix.python-version }} == ${{ "3.7" }}
+      - if: ${{ matrix.python-version }} == ${{ env.python-version-for-coveralls }}
         run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,17 +28,17 @@ jobs:
         run: echo "false"
       - if: true
         run: echo "true"
-      - if: ${{ matrix.python-version }} != '3.7'
+      - if: ${{ matrix.python-version }} != ${{ "3.7" }}
         run: pytest
-      - if: ${{ matrix.python-version }} == '3.7'
+      - if: ${{ matrix.python-version }} == ${{ "3.7" }}
         run: |
           coverage run -m --source=. pytest
           coverage lcov
-      - if: ${{ matrix.python-version }} == '3.7'
+      - if: ${{ matrix.python-version }} == ${{ "3.7" }}
         name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: ${{ matrix.python-version }} == '3.7'
+      - if: ${{ matrix.python-version }} == ${{ "3.7" }}
         run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - run: python --version
-      - run: echo ${{ matrix.python-version }} = ${{ env.python-version-for-coveralls }} >> ${{ run-coveralls }}
+      - run: echo ${{ matrix.python-version }} = ${{ env.python-version-for-coveralls }} >> $run-coveralls 
       - if: ! ${{ run-coveralls }}
         run: pytest
       - if: ${{ run-coveralls }}


### PR DESCRIPTION
Closes #11. I used if statements to make coveralls only run on the 3.7 python version. The other versions run `pytest`, which is what they did before coveralls was added.

I had to use multiple if statements for running coveralls on 3.7 because we are using the github action, and I couldn't find a way to combine the bash commands and the github action under one if statement.  

I had a lot of trouble with this one because the if statements would keep on evaluating as true even when I had opposite conditions in the if statements (like `${{ matrix.python-version }} == true` and `${{ matrix.python-version }} == false`). I learned variables in if statements shouldn't be surrounded by `${{}}`, otherwise the entire statement will always be evaluated as true. For more information, see the bottom of this [forum](https://github.com/actions/runner/issues/1173). I also learned that strings must be surrounded by quotes in if statements.