### PR TITLE
Variables test

### DIFF
--- a/.github/workflows/variablesTest.yml
+++ b/.github/workflows/variablesTest.yml
@@ -22,7 +22,7 @@ jobs:
       
       - name: Check for DOCKER_IMAGE_TAG change
         if: github.event_name == 'pull_request'
-        run: $env.DOCKER_IMAGE_TAG = ":refs_heads_${GITHUB_HEAD_REF}-bk0" >> 
+        run: $env.DOCKER_IMAGE_TAG = ":refs_heads_${GITHUB_HEAD_REF}-bk0"
 
       - name: Echo DOCKER_IMAGE_TAG again
         run: echo ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/variablesTest.yml
+++ b/.github/workflows/variablesTest.yml
@@ -22,7 +22,7 @@ jobs:
       
       - name: Check for DOCKER_IMAGE_TAG change
         if: github.event_name == 'pull_request'
-        run: $env.DOCKER_IMAGE_TAG = ":refs_heads_${GITHUB_HEAD_REF}-bk0"
+        run: $env.DOCKER_IMAGE_TAG=":refs_heads_${GITHUB_HEAD_REF}-bk0"
 
       - name: Echo DOCKER_IMAGE_TAG again
         run: echo ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/variablesTest.yml
+++ b/.github/workflows/variablesTest.yml
@@ -29,6 +29,7 @@ jobs:
         run: echo ${{ env.DOCKER_IMAGE_TAG }}
   
   check_permanence:
+    needs: [check_event]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/variablesTest.yml
+++ b/.github/workflows/variablesTest.yml
@@ -20,7 +20,7 @@ jobs:
           echo ${{ github.event_name }}
       
       - name: Check for DOCKER_IMAGE_TAG change
-        if: $GITHUB_EVENT_NAME == 'pull_request'
+        if: github.event_name == 'pull_request'
         run: echo ":refs_heads_${GITHUB_HEAD_REF}-bk0" >> $env.DOCKER_IMAGE_TAG
 
       - name: Echo DOCKER_IMAGE_TAG again

--- a/.github/workflows/variablesTest.yml
+++ b/.github/workflows/variablesTest.yml
@@ -22,7 +22,8 @@ jobs:
       
       - name: Check for DOCKER_IMAGE_TAG change
         if: github.event_name == 'pull_request'
-        run: $env.DOCKER_IMAGE_TAG=":refs_heads_${GITHUB_HEAD_REF}-bk0"
+        run: echo "DOCKER_IMAGE_TAG=:refs_heads_${GITHUB_HEAD_REF}-bk0" >> $GITHUB_ENV
+        
 
       - name: Echo DOCKER_IMAGE_TAG again
         run: echo ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/variablesTest.yml
+++ b/.github/workflows/variablesTest.yml
@@ -20,7 +20,7 @@ jobs:
           echo ${{ github.event_name }}
       
       - name: Check for DOCKER_IMAGE_TAG change
-        if: GITHUB_EVENT_NAME == 'pull_request'
+        if: $GITHUB_EVENT_NAME == 'pull_request'
         run: echo ":refs_heads_${GITHUB_HEAD_REF}-bk0" >> $env.DOCKER_IMAGE_TAG
 
       - name: Echo DOCKER_IMAGE_TAG again
@@ -31,6 +31,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        
+
       - name: Echo DOCKER_IMAGE_TAG again
         run: echo ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/variablesTest.yml
+++ b/.github/workflows/variablesTest.yml
@@ -1,0 +1,36 @@
+name: Test env variables
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+env: 
+  DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
+
+jobs:
+  check_event:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Echo variables
+        run: |
+          echo ${{ env.DOCKER_IMAGE_TAG }}
+          echo ${{ github.event_name }}
+      
+      - name: Check for DOCKER_IMAGE_TAG change
+        if: GITHUB_EVENT_NAME == 'pull_request'
+        run: echo ":refs_heads_${GITHUB_HEAD_REF}-bk0" >> $env.DOCKER_IMAGE_TAG
+
+      - name: Echo DOCKER_IMAGE_TAG again
+        run: echo ${{ env.DOCKER_IMAGE_TAG }}
+  
+  check_permanence:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Echo DOCKER_IMAGE_TAG again
+        run: echo ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/variablesTest.yml
+++ b/.github/workflows/variablesTest.yml
@@ -18,10 +18,11 @@ jobs:
         run: |
           echo ${{ env.DOCKER_IMAGE_TAG }}
           echo ${{ github.event_name }}
+          echo ${{ github.HEAD_REF }}
       
       - name: Check for DOCKER_IMAGE_TAG change
         if: github.event_name == 'pull_request'
-        run: echo ":refs_heads_${GITHUB_HEAD_REF}-bk0" >> $env.DOCKER_IMAGE_TAG
+        run: $env.DOCKER_IMAGE_TAG = ":refs_heads_${GITHUB_HEAD_REF}-bk0" >> 
 
       - name: Echo DOCKER_IMAGE_TAG again
         run: echo ${{ env.DOCKER_IMAGE_TAG }}


### PR DESCRIPTION
This pull request is a test to see if it is possible to change `env` variables based on whether the triggering event is a `pull_request` or a `push`. It also tests if these changes made in one job will endure into jobs that occur afterwards. 

This test is motivated by the [virtualbox PR on PyNE](https://github.com/pyne/pyne/pull/1498), which has the workflows being triggered by `pull_request` failing because `env.DOCKER_IMAGE_TAG` changes to something different than the tag of the images in `ghcr.io` when the triggering event is a `pull_request`.

This pull request doesn't need to be merged, and I will probably close it after I have worked out all the syntax and nuances necessary. I may also push this `variables-test` branch onto the `cnerg` repo instead of my forked repo if the workflow I added is not being run. 