### PR TITLE
Add workflow to output github.ref when the triggering event is a release

### DIFF
--- a/.github/workflows/releaseTest.yml
+++ b/.github/workflows/releaseTest.yml
@@ -1,0 +1,17 @@
+name: release-test
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+  release:
+
+jobs:
+  echo-variable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: See what github.ref is on release
+        run: echo ${{ github.ref }}


### PR DESCRIPTION
This PR adds a short workflow called `releaseTest.yml` whose purpose is to print out the value of the default variable `github.ref`. Although I mostly only care about the results when the event is a `release`, I also made the workflow run on `pull_request` and `push` just to see what the variable contains on those runs. 

After this PR is merged, I will create a new release on the `main` branch to trigger this workflow to see what `github.ref` is when the triggering event is `release`. 

This PR was motivated by a recent PR on the PyNE repo where we have decided to integrate the name of releases as a tag for the latest image as well as the name of the virtual machine. While this test is not completely necessary, I think it's still a good idea to verify that our intended use of `github.ref` does work as we think it will, especially since the results can only be obtained after merging a PR and creating a release. 