### PR TITLE
Use github.ref_name instead of github.ref

### DIFF
--- a/.github/workflows/releaseTest.yml
+++ b/.github/workflows/releaseTest.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: See what github.ref is on release
-        run: echo ${{ github.ref }}
+      - name: See what github.ref_name is on release
+        run: echo ${{ github.ref_name }}


### PR DESCRIPTION
A follow up to the [previous PR](https://github.com/cnerg/learn-maintenance/pull/28). The previous one used `github.ref`, which (on workflows run due to `release` events) contains more info than just the tag of the release. This PR aims to test if `github.ref_name` will only contain the tag of the release. 